### PR TITLE
update 4.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,8 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: A Python Perceptual Image Hahsing Module
+  description: |
+    An image hashing library written in Python.
   dev_url: https://github.com/JohannesBuchner/imagehash
   doc_url: https://github.com/JohannesBuchner/imagehash/blob/master/README.rst
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "imagehash" %}
-{% set version = "4.2.1" %}
-
+{% set version = "4.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,26 +7,24 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ImageHash-{{ version }}.tar.gz
-  sha256: a4af957814bc9832d9241247ff03f76e778f890c18147900b4540af124e93011
-
+  sha256: 7038d1b7f9e0585beb3dd8c0a956f02b95a346c0b5f24a9e8cc03ebadaf0aa70
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3
+    - python
     - numpy
     - pillow       # or PIL
     - pywavelets   # for whash
     - scipy        # for phash
-    - six
 
 test:
   imports:


### PR DESCRIPTION
## imagehash 4.3.1 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1356)
[Upstream](https://github.com/JohannesBuchner/imagehash/tree/v4.3.1)

# Changes
- Updated version number and `sha256`
- removed `six` as it is an outdated dependency that is not utilized anymore