### PR TITLE
imagehash 4.3.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set name = "imagehash" %}
-{% set version = "4.3.1" %}
+{% set name = "ImageHash" %}
+{% set version = "4.3.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ImageHash-{{ version }}.tar.gz
-  sha256: 7038d1b7f9e0585beb3dd8c0a956f02b95a346c0b5f24a9e8cc03ebadaf0aa70
+  url: https://github.com/JohannesBuchner/imagehash/archive/refs/tags/v4.3.2.tar.gz
+  sha256: 473f992da754b71ecc61c1fcfd4d4f999a0630a1475fd55e1d572016e043fdae
+
 build:
   number: 0
-  skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -21,18 +21,24 @@ requirements:
     - wheel
   run:
     - python
+    - pillow
     - numpy
-    - pillow       # or PIL
-    - pywavelets   # for whash
-    - scipy        # for phash
-
+    - scipy
+    - pywavelets
+    
 test:
+  source_files:
+    - tests
+    - README.rst
   imports:
     - imagehash
   commands:
     - pip check
+    - pytest -v tests
   requires:
     - pip
+    - pytest >3
+    - six
 
 about:
   home: https://github.com/JohannesBuchner/imagehash


### PR DESCRIPTION
imagehash 4.3.2 

**Destination channel:** Defaults

### Links

- [PKG-11879]
- dev_url:        https://github.com/JohannesBuchner/imagehash/tree/v4.3.2
- conda_forge:    https://github.com/conda-forge/imagehash-feedstock
- pypi:           https://pypi.org/project/imagehash/4.3.2
- pypi inspector: https://inspector.pypi.io/project/imagehash/4.3.2

### Explanation of changes:

- new version number


[PKG-11879]: https://anaconda.atlassian.net/browse/PKG-11879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ